### PR TITLE
Upadate labelencoder.py add get_feature_names_out method

### DIFF
--- a/src/condor_tensorflow/labelencoder.py
+++ b/src/condor_tensorflow/labelencoder.py
@@ -34,6 +34,15 @@ class CondorOrdinalEncoder(BaseEstimator, TransformerMixin):
             if len(X.shape) == 1:
                 X = X.reshape(-1, 1)
             self._enc.fit(X)
+        if hasattr(X, "columns"):
+            # pandas dataframes
+            self.feature_names_in_ = X.columns.tolist()
+        elif hasattr(X, "iloc"):
+            # pandas series
+            self.feature_names_in_ = [X.name]
+        elif hasattr(X, "shape"):
+            # numpy array
+            self.feature_names_in_ = ["X"]
         return self
 
     def transform(self, X):
@@ -71,3 +80,27 @@ class CondorOrdinalEncoder(BaseEstimator, TransformerMixin):
         # and use cumsum to fill
         X_out = np.flip(np.flip(X_out, 1).cumsum(axis=1), 1)
         return X_out
+
+    def get_feature_names_out(self, input_features=None):
+        """feature names transformation.
+        Parameters
+        ----------
+        input_features : str, a list of str of the same length as features fitted, or None.
+        If input_features is None, then feature_names_in_ is used as feature names in. If feature_names_in_ is not defined, then the following input feature names are generated: ["x1", "x2", ..., "x(nclasses - 1)"].
+        If input_features is an array-like, then input_features must match feature_names_in_ if feature_names_in_ is defined.
+        Returns
+        -------
+        X_out : ndarray of shape (n_classes-1)
+            Transformed feature names.
+        """
+        if isinstance(input_features, str):
+            input_features = [input_features for _ in self.feature_names_in_]
+        if input_features is None:
+            input_features = self.feature_names_in_
+        assert len(input_features)==len(self.feature_names_in_), 'length of input_features must be equal to length of fitted features'
+        retfeatureNames = [
+            featurename+str(level)
+            for level in range(1, self.nclasses)
+            for featurename in input_features
+        ]
+        return np.array(retfeatureNames, dtype=object)


### PR DESCRIPTION
When I try to integrate sklearn.compose.ColumnTransformer, sklearn.pipeline with condor encoder, I find it difficult and errors happen due to lack of support. Therefore I add the support of get_feature_names_out method, which complies with the structure of sklearn.